### PR TITLE
支持本地链接并修复箭头符号乱码

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -14,7 +14,7 @@
   <div class="bottom-container">
     <div class="bottom-controls">
       <div class="url-bar">
-        <input type="text" id="urlInput" placeholder="新标签页地址.....">
+        <input type="url" id="urlInput" placeholder="新标签页地址.....">
       </div>
       
       <button id="save" class="button">保存</button>

--- a/popup.js
+++ b/popup.js
@@ -15,14 +15,14 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   document.getElementById('save').addEventListener('click', () => {
-    const value = document.getElementById('urlInput').value
-    if (!regexp.test(value)) {
+    const urlInput = document.getElementById('urlInput')
+    if (!urlInput.checkValidity()) {
       setMessage('hint', '输入的链接地址不正确！', 'msg-error')
       setTimeout(() => {
         getNewTabUrl()
       }, 1000)
     } else {
-      setUrl(value, 'save')
+      setUrl(urlInput.value, 'save')
     }
   })
 
@@ -68,9 +68,14 @@ document.addEventListener('DOMContentLoaded', function () {
         'content'
       ).innerHTML = `<div class="${cls} message">${msg}</div>`
     } else if (type == 'link') {
+      if (regexp.test(url)) {
+        sethtml = `<div class="${cls} message" title="${url}"><a target="_blank" href="${url}">&#x27bc;${url}</a></div>`
+      } else {
+        sethtml = `<div class="${cls} message" title="${url}"><a>&#x27bc;${url}</a></div>`
+      }
       document.getElementById(
         'content'
-      ).innerHTML = `<div class="${cls} message" title="${url}"><a target="_blank" href="${url}">&#x27bc${url}</a></div>`
+      ).innerHTML = sethtml
     }
   }
 })


### PR DESCRIPTION
测试 `chrome-search://` 和 `file://` 通过（后者可能需要允许访问文件 URL）

经过测试，在配置页面点击本地链接工作不正常，屏蔽本地链接的点击功能

Fixes #4 
Fixes #5 
